### PR TITLE
chore: create naive render fetcher route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,4 @@ ENV/
 
 cdk.out/
 deployment/k8s/titiler/values-test.yaml
-
+.vscode

--- a/README.md
+++ b/README.md
@@ -154,3 +154,5 @@ See [CHANGES.md](https://github.com/developmentseed/titiler/blob/main/CHANGES.md
 
 Using 
 https://api.cogeo.xyz/stac/crop/14.869,37.682,15.113,37.862/256x256.png?url=https://raw.githubusercontent.com/alexberndt/titiler/refs/heads/add-render-endpoints/examples/item-sentinel2.json&assets=B12,B8A,B04&resampling_method=average&rescale=0,5000,0,7000,0,9000&return_mask=true 
+
+https://raw.githubusercontent.com/alexberndt/titiler/refs/heads/add-render-endpoints/examples/item-sentinel2.json

--- a/README.md
+++ b/README.md
@@ -150,3 +150,7 @@ See [contributors](https://github.com/developmentseed/titiler/graphs/contributor
 ## Changes
 
 See [CHANGES.md](https://github.com/developmentseed/titiler/blob/main/CHANGES.md).
+
+
+Using 
+https://api.cogeo.xyz/stac/crop/14.869,37.682,15.113,37.862/256x256.png?url=https://raw.githubusercontent.com/alexberndt/titiler/refs/heads/add-render-endpoints/examples/item-sentinel2.json&assets=B12,B8A,B04&resampling_method=average&rescale=0,5000,0,7000,0,9000&return_mask=true 

--- a/examples/item-sentinel2.json
+++ b/examples/item-sentinel2.json
@@ -1,0 +1,653 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+      "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/virtual-assets/v1.0.0/schema.json"
+    ],
+    "id": "S2B_33SVB_20210221_0_L2A",
+    "bbox": [
+      13.86148243891681,
+      36.95257399124932,
+      15.111074610520053,
+      37.94752813015372
+    ],
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            13.876381589019879,
+            36.95257399124932
+          ],
+          [
+            13.86148243891681,
+            37.942072015005024
+          ],
+          [
+            15.111074610520053,
+            37.94752813015372
+          ],
+          [
+            15.109620666835209,
+            36.95783951241028
+          ],
+          [
+            13.876381589019879,
+            36.95257399124932
+          ]
+        ]
+      ]
+    },
+    "properties": {
+      "datetime": "2021-02-21T10:00:17Z",
+      "platform": "sentinel-2b",
+      "constellation": "sentinel-2",
+      "instruments": [
+        "msi"
+      ],
+      "gsd": 10,
+      "view:off_nadir": 0,
+      "proj:epsg": 32633,
+      "sentinel:utm_zone": 33,
+      "sentinel:latitude_band": "S",
+      "sentinel:grid_square": "VB",
+      "sentinel:sequence": "0",
+      "sentinel:product_id": "S2B_MSIL2A_20210221T095029_N0214_R079_T33SVB_20210221T115149",
+      "sentinel:data_coverage": 100,
+      "eo:cloud_cover": 21.22,
+      "sentinel:valid_cloud_cover": true,
+      "renders": {
+        "sir": {
+          "title": "Shortwave Infra-red",
+          "assets": [
+            "B12",
+            "B08",
+            "B04"
+          ],
+          "rescale": [
+            [
+              0,
+              5000
+            ],
+            [
+              0,
+              7000
+            ],
+            [
+              0,
+              9000
+            ]
+          ],
+          "resampling": "nearest"
+        }
+      }
+    },
+    "collection": "sentinel-s2-l2a-cogs",
+    "assets": {
+      "metadata": {
+        "title": "Original XML metadata",
+        "type": "application/xml",
+        "roles": [
+          "metadata"
+        ],
+        "href": "metadata.xml"
+      },
+      "B01": {
+        "title": "Band 1 (coastal)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 60,
+        "eo:bands": [
+          {
+            "name": "B01",
+            "common_name": "coastal",
+            "center_wavelength": 0.4439,
+            "full_width_half_max": 0.027
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif",
+        "proj:shape": [
+          1830,
+          1830
+        ],
+        "proj:transform": [
+          60,
+          0,
+          399960,
+          0,
+          -60,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 20567,
+            "stats_mean": 2339.4759595597,
+            "stats_stddev": 3026.6973619954,
+            "stats_valid_percent": 99.83,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B02": {
+        "title": "Band 2 (blue)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 10,
+        "eo:bands": [
+          {
+            "name": "B02",
+            "common_name": "blue",
+            "center_wavelength": 0.4966,
+            "full_width_half_max": 0.098
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B02.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 19264,
+            "stats_mean": 2348.069117847,
+            "stats_stddev": 2916.5446249911,
+            "stats_valid_percent": 99.99,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B03": {
+        "title": "Band 3 (green)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 10,
+        "eo:bands": [
+          {
+            "name": "B03",
+            "common_name": "green",
+            "center_wavelength": 0.56,
+            "full_width_half_max": 0.045
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B03.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 18064,
+            "stats_mean": 2384.4680007438,
+            "stats_stddev": 2675.410513295,
+            "stats_valid_percent": 99.999,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B04": {
+        "title": "Band 4 (red)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 10,
+        "eo:bands": [
+          {
+            "name": "B04",
+            "common_name": "red",
+            "center_wavelength": 0.6645,
+            "full_width_half_max": 0.038
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B04.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 17200,
+            "stats_mean": 2273.9667970732,
+            "stats_stddev": 2618.272802792,
+            "stats_valid_percent": 99.999,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B05": {
+        "title": "Band 5",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B05",
+            "center_wavelength": 0.7039,
+            "full_width_half_max": 0.019
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B05.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 16842,
+            "stats_mean": 2634.1490243416,
+            "stats_stddev": 2634.1490243416,
+            "stats_valid_percent": 99.999,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B06": {
+        "title": "Band 6",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B06",
+            "center_wavelength": 0.7402,
+            "full_width_half_max": 0.018
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B06.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 16502,
+            "stats_mean": 3329.8844628619,
+            "stats_stddev": 2303.0096294469,
+            "stats_valid_percent": 99.999,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B07": {
+        "title": "Band 7",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B07",
+            "center_wavelength": 0.7825,
+            "full_width_half_max": 0.028
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B07.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B08": {
+        "title": "Band 8 (nir)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 10,
+        "eo:bands": [
+          {
+            "name": "B08",
+            "common_name": "nir",
+            "center_wavelength": 0.8351,
+            "full_width_half_max": 0.145
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B08.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B8A": {
+        "title": "Band 8A",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B8A",
+            "center_wavelength": 0.8648,
+            "full_width_half_max": 0.033
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B8A.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B09": {
+        "title": "Band 9",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 60,
+        "eo:bands": [
+          {
+            "name": "B09",
+            "center_wavelength": 0.945,
+            "full_width_half_max": 0.026
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B09.tif",
+        "proj:shape": [
+          1830,
+          1830
+        ],
+        "proj:transform": [
+          60,
+          0,
+          399960,
+          0,
+          -60,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B11": {
+        "title": "Band 11 (swir16)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B11",
+            "common_name": "swir16",
+            "center_wavelength": 1.6137,
+            "full_width_half_max": 0.143
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B11.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B12": {
+        "title": "Band 12 (swir22)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B12",
+            "common_name": "swir22",
+            "center_wavelength": 2.22024,
+            "full_width_half_max": 0.242
+          }
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B12.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "AOT": {
+        "title": "Aerosol Optical Thickness (AOT)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/AOT.tif",
+        "proj:shape": [
+          1830,
+          1830
+        ],
+        "proj:transform": [
+          60,
+          0,
+          399960,
+          0,
+          -60,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "WVP": {
+        "title": "Water Vapour (WVP)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/WVP.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "SCL": {
+        "title": "Scene Classification Map (SCL)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/SCL.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      }
+    },
+    "links": [
+      {
+        "rel": "collection",
+        "href": "./collection.json",
+        "type": "application/json",
+        "title": "Sentinel-2 L2A Cogs Collection"
+      }
+    ]
+  }

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -32,6 +32,7 @@ from titiler.core.middleware import (
 from titiler.extensions import (
     cogValidateExtension,
     cogViewerExtension,
+    renderExtension,
     stacExtension,
     stacViewerExtension,
 )
@@ -122,6 +123,7 @@ if not api_settings.disable_stac:
         router_prefix="/stac",
         extensions=[
             stacViewerExtension(),
+            renderExtension(),
         ],
     )
 

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -1457,12 +1457,7 @@ class MultiBaseTilerFactory(TilerFactory):
                         type="Feature",
                         bbox=bounds,
                         geometry=geometry,
-                        properties={
-                            asset: asset_info
-                            for asset, asset_info in src_dst.info(
-                                **asset_params.as_dict()
-                            ).items()
-                        },
+                        properties=dict(src_dst.info(**asset_params.as_dict()).items()),
                     )
 
         @self.router.get(

--- a/src/titiler/extensions/tests/fixtures/item.json
+++ b/src/titiler/extensions/tests/fixtures/item.json
@@ -1,0 +1,707 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+      "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/virtual-assets/v1.0.0/schema.json"
+    ],
+    "id": "S2B_33SVB_20210221_0_L2A",
+    "bbox": [
+      13.86148243891681,
+      36.95257399124932,
+      15.111074610520053,
+      37.94752813015372
+    ],
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            13.876381589019879,
+            36.95257399124932
+          ],
+          [
+            13.86148243891681,
+            37.942072015005024
+          ],
+          [
+            15.111074610520053,
+            37.94752813015372
+          ],
+          [
+            15.109620666835209,
+            36.95783951241028
+          ],
+          [
+            13.876381589019879,
+            36.95257399124932
+          ]
+        ]
+      ]
+    },
+    "properties": {
+      "datetime": "2021-02-21T10:00:17Z",
+      "platform": "sentinel-2b",
+      "constellation": "sentinel-2",
+      "instruments": [
+        "msi"
+      ],
+      "gsd": 10,
+      "view:off_nadir": 0,
+      "proj:epsg": 32633,
+      "sentinel:utm_zone": 33,
+      "sentinel:latitude_band": "S",
+      "sentinel:grid_square": "VB",
+      "sentinel:sequence": "0",
+      "sentinel:product_id": "S2B_MSIL2A_20210221T095029_N0214_R079_T33SVB_20210221T115149",
+      "sentinel:data_coverage": 100,
+      "eo:cloud_cover": 21.22,
+      "sentinel:valid_cloud_cover": true
+    },
+    "collection": "sentinel-s2-l2a-cogs",
+    "assets": {
+      "metadata": {
+        "title": "Original XML metadata",
+        "type": "application/xml",
+        "roles": [
+          "metadata"
+        ],
+        "href": "metadata.xml"
+      },
+      "trc": {
+        "title": "True color image",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "visual",
+          "data",
+          "virtual"
+        ],
+        "gsd": 10,
+        "href": "https://raw.githubusercontent.com/stac-extensions/virtual-assets/main/examples/item-sentinel2.json#/assets/trc",
+        "vrt:hrefs": [
+          {
+            "key": "B04",
+            "href": "#/assets/B04"
+          },
+          {
+            "key": "B03",
+            "href": "#/assets/B03"
+          },
+          {
+            "key": "B02",
+            "href": "#/assets/B02"
+          }
+        ]
+      },
+      "sir": {
+        "title": "Shortwave Infra-red",
+        "href": "https://raw.githubusercontent.com/stac-extensions/virtual-assets/main/examples/item-sentinel2.json/assets/sir",
+        "vrt:hrefs": [
+          {
+            "key": "B12",
+            "href": "#/assets/B12"
+          },
+          {
+            "key": "B8A",
+            "href": "#/assets/B8A"
+          },
+          {
+            "key": "B11",
+            "href": "#/assets/B11"
+          }
+        ],
+        "roles": [
+          "sir",
+          "visual",
+          "data",
+          "virtual"
+        ],
+        "gsd": 10,
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized"
+      },
+      "ndvi": {
+        "roles": [
+          "virtual",
+          "data",
+          "index"
+        ],
+        "href": "https://maps.example.com/collections/sentinel-s2-l2a-cogs/items/S2B_33SVB_20210221_0_L2A.json#/assets/ndvi",
+        "vrt:hrefs": [
+          {
+            "key": "B04",
+            "href": "#/assets/B04"
+          },
+          {
+            "key": "B05",
+            "href": "#/assets/B05"
+          }
+        ],
+        "title": "Normalized Difference Vegetation Index",
+        "vrt:algorithm": "band_arithmetic",
+        "vrt:algorithm_opts": {
+          "expression": "(B05–B04)/(B05+B04)",
+          "rescale": [
+            [
+              -1,
+              1
+            ]
+          ]
+        }
+      },
+      "B01": {
+        "title": "Band 1 (coastal)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 60,
+        "eo:bands": [
+          {
+            "name": "B01",
+            "common_name": "coastal",
+            "center_wavelength": 0.4439,
+            "full_width_half_max": 0.027
+          }
+        ],
+        "href": "B01.tif",
+        "proj:shape": [
+          1830,
+          1830
+        ],
+        "proj:transform": [
+          60,
+          0,
+          399960,
+          0,
+          -60,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 20567,
+            "stats_mean": 2339.4759595597,
+            "stats_stddev": 3026.6973619954,
+            "stats_valid_percent": 99.83,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B02": {
+        "title": "Band 2 (blue)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 10,
+        "eo:bands": [
+          {
+            "name": "B02",
+            "common_name": "blue",
+            "center_wavelength": 0.4966,
+            "full_width_half_max": 0.098
+          }
+        ],
+        "href": "B02.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 19264,
+            "stats_mean": 2348.069117847,
+            "stats_stddev": 2916.5446249911,
+            "stats_valid_percent": 99.99,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B03": {
+        "title": "Band 3 (green)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 10,
+        "eo:bands": [
+          {
+            "name": "B03",
+            "common_name": "green",
+            "center_wavelength": 0.56,
+            "full_width_half_max": 0.045
+          }
+        ],
+        "href": "B03.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 18064,
+            "stats_mean": 2384.4680007438,
+            "stats_stddev": 2675.410513295,
+            "stats_valid_percent": 99.999,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B04": {
+        "title": "Band 4 (red)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 10,
+        "eo:bands": [
+          {
+            "name": "B04",
+            "common_name": "red",
+            "center_wavelength": 0.6645,
+            "full_width_half_max": 0.038
+          }
+        ],
+        "href": "B04.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 17200,
+            "stats_mean": 2273.9667970732,
+            "stats_stddev": 2618.272802792,
+            "stats_valid_percent": 99.999,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B05": {
+        "title": "Band 5",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B05",
+            "center_wavelength": 0.7039,
+            "full_width_half_max": 0.019
+          }
+        ],
+        "href": "B05.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 16842,
+            "stats_mean": 2634.1490243416,
+            "stats_stddev": 2634.1490243416,
+            "stats_valid_percent": 99.999,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B06": {
+        "title": "Band 6",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B06",
+            "center_wavelength": 0.7402,
+            "full_width_half_max": 0.018
+          }
+        ],
+        "href": "B06.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ],
+        "raster:bands": [
+          {
+            "data_type": "uint16",
+            "nodata": 0,
+            "stats_min": 1,
+            "stats_max": 16502,
+            "stats_mean": 3329.8844628619,
+            "stats_stddev": 2303.0096294469,
+            "stats_valid_percent": 99.999,
+            "values": [
+              {
+                "name": "BOA reflectance"
+              }
+            ]
+          }
+        ]
+      },
+      "B07": {
+        "title": "Band 7",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B07",
+            "center_wavelength": 0.7825,
+            "full_width_half_max": 0.028
+          }
+        ],
+        "href": "B07.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B08": {
+        "title": "Band 8 (nir)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 10,
+        "eo:bands": [
+          {
+            "name": "B08",
+            "common_name": "nir",
+            "center_wavelength": 0.8351,
+            "full_width_half_max": 0.145
+          }
+        ],
+        "href": "B08.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B8A": {
+        "title": "Band 8A",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B8A",
+            "center_wavelength": 0.8648,
+            "full_width_half_max": 0.033
+          }
+        ],
+        "href": "B8A.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B09": {
+        "title": "Band 9",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 60,
+        "eo:bands": [
+          {
+            "name": "B09",
+            "center_wavelength": 0.945,
+            "full_width_half_max": 0.026
+          }
+        ],
+        "href": "B09.tif",
+        "proj:shape": [
+          1830,
+          1830
+        ],
+        "proj:transform": [
+          60,
+          0,
+          399960,
+          0,
+          -60,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B11": {
+        "title": "Band 11 (swir16)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B11",
+            "common_name": "swir16",
+            "center_wavelength": 1.6137,
+            "full_width_half_max": 0.143
+          }
+        ],
+        "href": "B11.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "B12": {
+        "title": "Band 12 (swir22)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "gsd": 20,
+        "eo:bands": [
+          {
+            "name": "B12",
+            "common_name": "swir22",
+            "center_wavelength": 2.22024,
+            "full_width_half_max": 0.242
+          }
+        ],
+        "href": "B12.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "AOT": {
+        "title": "Aerosol Optical Thickness (AOT)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "href": "AOT.tif",
+        "proj:shape": [
+          1830,
+          1830
+        ],
+        "proj:transform": [
+          60,
+          0,
+          399960,
+          0,
+          -60,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "WVP": {
+        "title": "Water Vapour (WVP)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "href": "WVP.tif",
+        "proj:shape": [
+          10980,
+          10980
+        ],
+        "proj:transform": [
+          10,
+          0,
+          399960,
+          0,
+          -10,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      },
+      "SCL": {
+        "title": "Scene Classification Map (SCL)",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": [
+          "data"
+        ],
+        "href": "SCL.tif",
+        "proj:shape": [
+          5490,
+          5490
+        ],
+        "proj:transform": [
+          20,
+          0,
+          399960,
+          0,
+          -20,
+          4200000,
+          0,
+          0,
+          1
+        ]
+      }
+    },
+    "links": [
+      {
+        "rel": "collection",
+        "href": "./collection.json",
+        "type": "application/json",
+        "title": "Sentinel-2 L2A Cogs Collection"
+      }
+    ]
+  }

--- a/src/titiler/extensions/tests/test_render.py
+++ b/src/titiler/extensions/tests/test_render.py
@@ -1,0 +1,26 @@
+"""Test TiTiler render extension."""
+
+import os
+
+from fastapi import FastAPI
+from rio_tiler.io import STACReader
+from starlette.testclient import TestClient
+
+from titiler.core.factory import TilerFactory
+from titiler.extensions import renderExtension
+
+stac_item = os.path.join(os.path.dirname(__file__), "fixtures", "item.json")
+
+
+def test_renderExtension():
+    """Test renderExtension class."""
+    tiler = TilerFactory()
+    tiler_plus_render = TilerFactory(reader=STACReader, extensions=[renderExtension()])
+    # Check that we added one route (/renders)
+    assert len(tiler_plus_render.router.routes) == len(tiler.router.routes) + 1
+
+    app = FastAPI()
+    app.include_router(tiler_plus_render.router)
+    with TestClient(app) as client:
+        response = client.get("/renders", params={"url": stac_item})
+        assert response.status_code == 200

--- a/src/titiler/extensions/titiler/extensions/__init__.py
+++ b/src/titiler/extensions/titiler/extensions/__init__.py
@@ -3,6 +3,7 @@
 __version__ = "0.19.1"
 
 from .cogeo import cogValidateExtension  # noqa
+from .render import renderExtension  # noqa
 from .stac import stacExtension  # noqa
 from .viewer import cogViewerExtension, stacViewerExtension  # noqa
 from .wms import wmsExtension  # noqa

--- a/src/titiler/extensions/titiler/extensions/render.py
+++ b/src/titiler/extensions/titiler/extensions/render.py
@@ -3,7 +3,8 @@
 from typing import Dict
 
 from attrs import define
-from fastapi import Depends
+from fastapi import Depends, Query
+from typing_extensions import Annotated
 
 from titiler.core.factory import FactoryExtension, MultiBaseTilerFactory
 
@@ -18,10 +19,47 @@ class renderExtension(FactoryExtension):
         @factory.router.get(
             "/renders", response_model=Dict, name="Show STAC item render options"
         )
-        def render(src_path=Depends(factory.path_dependency)):
+        def renders(src_path=Depends(factory.path_dependency)):
             """Show render options for STAC item."""
             with factory.reader(src_path) as src:
-                renders = {}
-                if "renders" in src.item.properties:
-                    renders = src.item.properties.get("renders")
+                renders = src.item.properties.get("renders", {})
+
+                # Create query from
+
                 return {"renders": renders}
+
+        @factory.router.get(
+            "/render", response_model=Dict, name="Get URL for render type"
+        )
+        def render(
+            render_name: Annotated[
+                str,
+                Query(description="render name for the source."),
+            ],
+            src_path=Depends(factory.path_dependency),
+        ):
+            """Return URL for a render item."""
+            with factory.reader(src_path) as src:
+                renders = src.item.properties.get("renders", {})
+                if len(renders) == 0:
+                    return "no renders in provided item"
+                if render_name not in renders:
+                    return f"render {render_name} not found"
+
+                render = renders[render_name]
+
+                # read render details from payload
+                params = []
+
+                if "assets" in render:
+                    params.append(f"assets={','.join(render['assets'])}")
+                if "rescale" in render:
+                    params.append(
+                        f"rescale={','.join([str(limit) for band in render['rescale'] for limit in band])}"
+                    )
+                if "resampling" in render:
+                    params.append(f"resmapling={render['resampling']}")
+
+                prefix = "https://api.cogeo.xyz/stac/crop/14.869,37.682,15.113,37.862/256x256.png"
+
+                return {"url": f"{prefix}?url={src_path}&{'&'.join(params)}"}

--- a/src/titiler/extensions/titiler/extensions/render.py
+++ b/src/titiler/extensions/titiler/extensions/render.py
@@ -1,0 +1,27 @@
+"""rio-stac render Extension."""
+
+from typing import Dict
+
+from attrs import define
+from fastapi import Depends
+
+from titiler.core.factory import FactoryExtension, MultiBaseTilerFactory
+
+
+@define
+class renderExtension(FactoryExtension):
+    """Add /render endpoint to a COG TilerFactory."""
+
+    def register(self, factory: MultiBaseTilerFactory):
+        """Register endpoint to the tiler factory."""
+
+        @factory.router.get(
+            "/renders", response_model=Dict, name="Show STAC item render options"
+        )
+        def render(src_path=Depends(factory.path_dependency)):
+            """Show render options for STAC item."""
+            with factory.reader(src_path) as src:
+                renders = {}
+                if "renders" in src.item.properties:
+                    renders = src.item.properties.get("renders")
+                return {"renders": renders}

--- a/src/titiler/extensions/titiler/extensions/templates/stac_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/stac_viewer.html
@@ -201,17 +201,26 @@
 
     <div id='menu' class='flex-child w240 w360-ml absolute bg-gray-faint z2 off'>
       <div id='asset-section' class='px6 py6 wmax-full'>
+        <div class='pt6'>Select asset composition mode</div>
+        <!-- <label class='switch-container'> -->
+          
+          <input type="radio" id="composition-mode-single" name="composition-mode" value="single" checked="checked"> Single
+          <input type="radio" id="composition-mode-multi" name="composition-mode" value="multi"> Multi
+          <input type="radio" id="composition-mode-render" name="composition-mode" value="render"> Render
+        
+          <!-- <input id='compose-switch' type='checkbox' /> -->
+          <!-- <div class='switch'></div> -->
+        
+        
+        <!-- </label> -->
+      </div>
+        
         <div class='txt-h5 mb6 color-black'><svg class='icon icon--l inline-block'><use xlink:href='#icon-layers' /></svg>Assets</div>
         <div class='select-container'>
           <select id='asset-selector' class='select select--s select--stroke pl6 wmax-full'></select>
           <div class='select-arrow color-black'></div>
         </div>
-        <div class='pt6'>Allow assets composition</div>
-        <label class='switch-container'>
-          <input id='compose-switch' type='checkbox' />
-          <div class='switch'></div>
-        </label>
-      </div>
+        
 
       <ul id='toolbar' class='grid'>
         <li id='3b' class="col col--6 active" title="rgb" onclick="switchPane(this)">
@@ -482,18 +491,22 @@ const set3bViz = () => {
 
   let asset_params
   let indexes_params
-  if (document.getElementById("compose-switch").checked === true) {
+  if (document.getElementById("composition-mode-single").checked === true) {
     asset_params = [r, g, b].map(i => `assets=${i}`).join('&')
     // When doing assets composition we select the first band (bidx=1)
     indexes_params =  [r, g, b].map(i => `asset_bidx=${i}|1`).join('&')
     params.rescale = `${document.getElementById('data-min').value},${document.getElementById('data-max').value}`
-  } else {
+  } else if ((document.getElementById("composition-mode-multi").checked === true)) {
     const asset = document.getElementById('asset-selector').value
     asset_params = `assets=${asset}`
     indexes_params =  `asset_bidx=${asset}|${r},${g},${b}`
     if (['uint8','int8'].indexOf(scope.dataset_info[asset].dtype) === -1) {
       params.rescale = `${document.getElementById('data-min').value},${document.getElementById('data-max').value}`
     }
+  } else if ((document.getElementById("composition-mode-render").checked === true)) {
+    console.log("hello from the render side")
+  } else {
+    console.log("Unknown composition mode")
   }
 
   if (document.getElementById('ColorFormulaValue').value !== '') {
@@ -514,16 +527,20 @@ const addHisto3Bands = () => {
   let rStats
   let gStats
   let bStats
-  if (document.getElementById("compose-switch").checked === true) {
+  if (document.getElementById("composition-mode-single").checked === true) {
     // When doing assets composition we select the first band (b1)
     rStats = scope.dataset_statistics[r]['b1']
     gStats = scope.dataset_statistics[g]['b1']
     bStats = scope.dataset_statistics[b]['b1']
-  } else {
+  } else if (document.getElementById("composition-mode-multi").checked === true) {
     const asset = document.getElementById('asset-selector').value
     rStats = scope.dataset_statistics[asset][r]
     gStats = scope.dataset_statistics[asset][g]
     bStats = scope.dataset_statistics[asset][b]
+  } else if (document.getElementById("composition-mode-render").checked === true) {
+    console.log("Hello from the render side 2")
+  } else {
+    console.log("invalid composition mode provided")
   }
 
   const minV = Math.min(...[rStats.min, gStats.min, bStats.min])
@@ -756,7 +773,13 @@ document.getElementById('asset-selector').addEventListener('change', () => {
   updateViz()
 })
 
-document.getElementById('compose-switch').addEventListener('change', () => {
+document.getElementById('composition-mode-single').addEventListener('change', () => {
+  updateUI()
+})
+document.getElementById('composition-mode-multi').addEventListener('change', () => {
+  updateUI()
+})
+document.getElementById('composition-mode-render').addEventListener('change', () => {
   updateUI()
 })
 
@@ -808,7 +831,7 @@ const bboxPolygon = (bounds) => {
 }
 
 const updateUI = () => {
-  const is_checked = document.getElementById("compose-switch").checked
+  // const is_checked = document.getElementById("compose-switch").checked
   const rList = document.getElementById('r-selector')
   rList.innerHTML = ''
   const bList = document.getElementById('b-selector')
@@ -817,7 +840,7 @@ const updateUI = () => {
   gList.innerHTML = ''
 
   // Allow assets composition (Asset As Band)
-  if (is_checked === true) {
+  if (document.getElementById("composition-mode-single").checked === true) {
     document.getElementById('asset-selector').classList.add('disabled')
     document.getElementById("asset-selector").disabled = true
 
@@ -865,7 +888,7 @@ const updateUI = () => {
     const mm = dtype_ranges[scope.dataset_info[scope.assets[0]].dtype]
     document.getElementById('data-min').value = mm[0]
     document.getElementById('data-max').value = mm[1]
-  } else {
+  } else if (document.getElementById("composition-mode-multi").checked === true) {
     document.getElementById('1b').classList.remove('disabled')
     document.getElementById("asset-selector").disabled = false
 
@@ -918,6 +941,17 @@ const updateUI = () => {
     } else {
       document.getElementById('3b').classList.remove('disabled')
     }
+  } else if (document.getElementById("composition-mode-render").checked === true) {
+    console.log("hello from the render side 3")
+  } else {
+    console.log("invalid composition mode")
+    console.log(document.getElementById("composition-mode-single"))
+    console.log(document.getElementById("composition-mode-single").checked)
+    console.log(document.getElementById("composition-mode-multi"))
+    console.log(document.getElementById("composition-mode-multi").checked)
+    console.log(document.getElementById("composition-mode-render"))
+    console.log(document.getElementById("composition-mode-render").checked)
+    console.log(document.getElementById("composition-mode-render").checked === true)
   }
   updateViz()
 }

--- a/src/titiler/extensions/titiler/extensions/viewer.py
+++ b/src/titiler/extensions/titiler/extensions/viewer.py
@@ -62,6 +62,7 @@ class stacViewerExtension(FactoryExtension):
                     ),
                     "info_endpoint": factory.url_for(request, "info_geojson"),
                     "statistics_endpoint": factory.url_for(request, "asset_statistics"),
+                    "renders_endpoint": "http://localhost:8081/stac/renders",  # factory.url_for(request, "renders"),
                 },
                 media_type="text/html",
             )


### PR DESCRIPTION
Using link https://raw.githubusercontent.com/cogeotiff/rio-tiler/refs/heads/main/tests/fixtures/stac_netcdf.json as a test

Using https://raw.githubusercontent.com/stac-extensions/render/refs/heads/main/examples/item-landsat8.json obtained from https://github.com/stac-extensions/render/tree/main/examples as examples of stac items containing render metadata.